### PR TITLE
Redirect to eventbrite on OAuth dance complete

### DIFF
--- a/backend/applications/views.py
+++ b/backend/applications/views.py
@@ -136,4 +136,7 @@ def callback(request):
 
     request.session["given_name"] = user_data["given_name"]
     request.session["eventbrite_code"] = eventbrite_code
-    return redirect("/")
+    return redirect("{}?discount={}".format(
+        os.environ["EVENT_LINK"],
+        eventbrite_code,
+    ))


### PR DESCRIPTION
I did some "user research" and found out that the current setup doesn't make it obvious that that you need to complete registration on Eventbrite. This PR automatically redirects a user to eventbrite at the end of the OAuth dance